### PR TITLE
chore: update makerules.mk to match the runtime version (spec from S3)

### DIFF
--- a/makerules/makerules.mk
+++ b/makerules/makerules.mk
@@ -23,6 +23,10 @@ ifeq ($(CONFIG_URL),)
 CONFIG_URL=$(DATASTORE_URL)config/
 endif
 
+ifeq ($(SPECIFICATION_URL),)
+SPECIFICATION_URL=$(DATASTORE_URL)specification/
+endif
+
 ifeq ($(COLLECTION_NAME),)
 COLLECTION_NAME=$(shell echo "$(REPOSITORY)"|sed 's/-collection$$//')
 endif
@@ -122,26 +126,20 @@ makerules::
 	curl -qfsL '$(MAKERULES_URL)makerules.mk' > makerules/makerules.mk
 
 ifeq (,$(wildcard ./makerules/specification.mk))
-# update local copies of specification files
-specification::
-	@mkdir -p specification/
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/attribution.csv' > specification/attribution.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/licence.csv' > specification/licence.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/typology.csv' > specification/typology.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/theme.csv' > specification/theme.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/collection.csv' > specification/collection.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/dataset.csv' > specification/dataset.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/dataset-field.csv' > specification/dataset-field.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/field.csv' > specification/field.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/datatype.csv' > specification/datatype.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/prefix.csv' > specification/prefix.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/provision-rule.csv' > specification/provision-rule.csv
-	# deprecated ..
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/pipeline.csv' > specification/pipeline.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/dataset-schema.csv' > specification/dataset-schema.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/schema.csv' > specification/schema.csv
-	curl -qfsL '$(SOURCE_URL)/specification/main/specification/schema-field.csv' > specification/schema-field.csv
+# update local copies of specification files (S3 in AWS, CDN locally — same as organisation.csv)
+SPECIFICATION_CSVS=\
+	attribution licence typology theme collection dataset dataset-field \
+	field datatype prefix provision-rule pipeline dataset-schema schema schema-field
 
+specification:: $(addprefix specification/,$(addsuffix .csv,$(SPECIFICATION_CSVS)))
+
+specification/%.csv:
+	@mkdir -p specification/
+ifneq ($(COLLECTION_DATASET_BUCKET_NAME),)
+	aws s3 cp s3://$(COLLECTION_DATASET_BUCKET_NAME)/specification/$(notdir $@) $@ --no-progress
+else
+	curl -qfsL '$(SPECIFICATION_URL)$(notdir $@)?version=$(shell date +%s)' -o $@
+endif
 
 init::	specification
 endif


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updating makerules.mk to match the runtime version (spec from S3).

## Why

This change doesn't actually affect what runs at runtime, because this file gets overwritten by the latest version from the makerules repo (via the `make makerules` target). However, I'm making the change to keep the committed code consistent with what actually runs, and to avoid future devs seeing an unexpected diff appear in this file after running `make`.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2739)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: just a chore, no actual change in functionality.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
